### PR TITLE
remove duplicated event description

### DIFF
--- a/content/sdk/android/guide.md
+++ b/content/sdk/android/guide.md
@@ -109,11 +109,6 @@ class MyActivity extends Activity {
         android:launchMode="singleInstance"
         android:theme="@android:style/Theme.Translucent" />
 
-    <service android:name="com.growthpush.TokenRefreshService">
-        <intent-filter>
-            <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
-        </intent-filter>
-    </service>
     <service android:name="com.growthpush.ReceiverService">
         <intent-filter>
             <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/content/sdk/android/reference.md
+++ b/content/sdk/android/reference.md
@@ -252,11 +252,6 @@ Growth Pushダイアログプッシュ通知を表示するときに必要とな
     android:launchMode="singleInstance"
     android:theme="@android:style/Theme.Translucent" />
 
-<service android:name="com.growthpush.TokenRefreshService">
-    <intent-filter>
-        <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
-    </intent-filter>
-</service>
 <service android:name="com.growthpush.ReceiverService">
     <intent-filter>
         <action android:name="com.google.firebase.MESSAGING_EVENT" />


### PR DESCRIPTION
# FIX
## remove duplicated event descriptions
firebase.INSTANCE_ID_EVENT is duplicated.
Growthbeat Android SDK support from v2.0.11, but descriptions were not deleted.